### PR TITLE
fix: Add peer dependencies to match tslint-folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,10 @@
         "typedoc": "^0.15.6",
         "typescript": "^3.7.4"
     },
-    "peerDependencies": {},
+    "peerDependencies": {
+        "tslint": ">=5.9.1 || >=^5.11.0",
+        "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >=3.1.0-dev || >=3.2.0-dev || >=3.3.0-dev"
+    },
     "engines": {
         "node": ">=10.18.0"
     },


### PR DESCRIPTION
fix: Add peer dependencies to match tslint-folders

Fixes warnings that show with yarn 2

fixes #24 